### PR TITLE
Stop automatically adding a .exe extension to windows output file. 

### DIFF
--- a/common-backend/src/main/java/org/ow2/mind/io/BasicOutputFileLocator.java
+++ b/common-backend/src/main/java/org/ow2/mind/io/BasicOutputFileLocator.java
@@ -69,15 +69,9 @@ public class BasicOutputFileLocator implements OutputFileLocator {
     return mkdirs(new File(outDir, path));
   }
 
-  public File getCExecutableOutputFile(String path,
+  public File getCExecutableOutputFile(final String path,
       final Map<Object, Object> context) {
     final File outDir = getOutputDir(context);
-
-    // ensure that executable path on Windows ends with ".exe".
-    if (System.getProperty("os.name").contains("Windows")
-        && !path.endsWith(".exe")) {
-      path = path + ".exe";
-    }
 
     return mkdirs(new File(outDir, path));
   }


### PR DESCRIPTION
This is especially useful when producing libraries for example.
This fix is trivial, BUT it might break build system assuming that the ".exe" will be added to mindc output  on windows.
