### PR TITLE
If the option isn't found (=null), return false instead of NPE.

### DIFF
--- a/mindc/src/main/java/org/ow2/mind/cli/CmdOptionBooleanEvaluator.java
+++ b/mindc/src/main/java/org/ow2/mind/cli/CmdOptionBooleanEvaluator.java
@@ -70,7 +70,7 @@ public class CmdOptionBooleanEvaluator implements BooleanEvaluator {
     Assert.assertNotNull(context,
         "CmdOptionBooleanEvaluator can't find option with id '" + id + "'.");
 
-    if (!cmdOption.isPresent(cmdLine)) {
+    if ((cmdOption == null) || !cmdOption.isPresent(cmdLine)) {
       return false;
     }
 


### PR DESCRIPTION
This fix is very useful for our mindoc "plugin-ification" when using static command-line options, with other plugin-contributed flags loading disabled, and encountering such flags lead us to this "null" value as flag wasn't found (as its provider wasn't loaded).
